### PR TITLE
Add ecs-logging-python to Loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ECS Logging - Common resources and issues for the language specific ECS loggers
 * [JavaScript](https://github.com/elastic/ecs-logging-js)
   * [Winston](https://github.com/elastic/ecs-logging-js/tree/master/loggers/winston)
   * [Morgan](https://github.com/elastic/ecs-logging-js/tree/master/loggers/morgan)
+* [Python](https://github.com/elastic/ecs-logging-python)
 
 ## APM
 


### PR DESCRIPTION
ecs-logging-python (`ecs-logging` on PyPI) supports the standard library logger and structlog but all under one package, not sure if we should have the sub-items in the list for that as is the case for others?