### PR TITLE
Add Go zap logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
   * [Winston](https://github.com/elastic/ecs-logging-js/tree/master/loggers/winston)
   * [Morgan](https://github.com/elastic/ecs-logging-js/tree/master/loggers/morgan)
 * [Python](https://github.com/elastic/ecs-logging-python)
+* Go
+  * [zap](https://github.com/elastic/ecs-logging-go-zap)
 
 ## APM
 


### PR DESCRIPTION
Are there plans to add integrations with other Go loggers, too? Not sure how the Go logging ecosystem looks like and what the market share of each logger is.