### PR TITLE
Add tracing fields to spec

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -60,6 +60,8 @@ The following example describes a richer set of fields in an event that has not 
         "app_uptime": "2016-05-15T14:03:12.345Z"
     },
     "tags": ["production", "env001"],
+    "trace.id": "4bf92f3577b34da6a3ce929d0e0e4736",
+    "transaction.id": "00f067aa0ba902b7"
 }
 ```
 

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -38,6 +38,18 @@
                     "substitute": "_"
                 }
             }
+        },
+        "trace.id": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
+            "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
+        },
+        "transaction.id": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
+            "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
         }
     }
 }


### PR DESCRIPTION
I'm deliberately not adding the `span.id` for now. While it can be useful to correlate a log to a specific span, I'm skeptical whether the value is worth the additional overhead.

If an application is doing thousands of short-lived spans, the `span.id` would have to be converted from the internal (probably binary) representation into a string and placed in a context, even if there's no corresponding log event. At least that's how it would be in Java. Agents and loggers in other languages might behave differently. But I'd argue it probably doesn't make sense to add the `span.id` to only some agents' log correlation features.

Also, there's a good workaround for span/log correlation: We can look at the logs with the same `transaction.id` as the span in the time between the start and the end of the span.