### PR TITLE
Add service.name and event.dataset to spec

### DIFF
--- a/spec/spec.json
+++ b/spec/spec.json
@@ -50,6 +50,19 @@
             "required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
             "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
+        },
+        "service.name": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "comment": "Configurable by users. When an APM agent is active, they should auto-configure it if not already set."
+        },
+        "event.dataset": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
+            "default": "${service.name}.log/${service.name}.${appender.name}",
+            "comment": "Configurable by users. By default derived from the service.name. When logging is auto-configured by APM Agents, they should set this to the log appender name if available. The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
         }
     }
 }

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -55,14 +55,27 @@
             "type": "string",
             "required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
-            "comment": "Configurable by users. When an APM agent is active, they should auto-configure it if not already set."
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, they should auto-configure it if not already set."
+            ]
         },
         "event.dataset": {
             "type": "string",
             "required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
-            "default": "${service.name}.log/${service.name}.${appender.name}",
-            "comment": "Configurable by users. By default derived from the service.name. When logging is auto-configured by APM Agents, they should set this to the log appender name if available. The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
+            "default": "${service.name}.log OR ${service.name}.${appender.name}",
+            "comment": [
+                "Configurable by users.",
+                "If the user manually configures the service name,",
+                "the logging library should set `event.dataset=${service.name}.log` if not explicitly configured otherwise.",
+                "",
+                "When agents auto-configure the app to use an ECS logger,",
+                "they should set `event.dataset=${service.name}.${appender.name}` if the appender name is available in the logging library.",
+                "Otherwise, agents should also set `event.dataset=${service.name}.log`",
+                "",
+                "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
+            ]
         }
     }
 }


### PR DESCRIPTION
@elastic/ecs-logging FYI

The `event.dataset` is quite important for the [log anomaly detection](https://www.elastic.co/guide/en/observability/current/inspect-log-anomalies.html).

See also https://github.com/elastic/ecs-logging-java/issues/58