### PR TITLE
Specify which fields are allowed to be nested

### DIFF
--- a/spec/spec.json
+++ b/spec/spec.json
@@ -15,7 +15,7 @@
             "type": "string",
             "required": true,
             "index": 1,
-            "nesting_required": true,
+            "nesting_allowed": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html"
         },
         "message": {
@@ -27,7 +27,6 @@
         "ecs.version": {
             "type": "string",
             "required": true,
-            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html"
         },
         "labels": {
@@ -44,21 +43,18 @@
         "trace.id": {
             "type": "string",
             "required": false,
-            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
             "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
         },
         "transaction.id": {
             "type": "string",
             "required": false,
-            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
             "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
         },
         "service.name": {
             "type": "string",
             "required": false,
-            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
             "comment": [
                 "Configurable by users.",
@@ -68,7 +64,6 @@
         "event.dataset": {
             "type": "string",
             "required": false,
-            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
             "default": "${service.name}.log OR ${service.name}.${appender.name}",
             "comment": [

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -21,8 +21,8 @@
                 "This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.",
                 "This is to make the JSON logs more human-readable.",
                 "Loggers MAY indent the log level so that the `message` field always starts at the exact same offset,",
-                "no matter the number of character the log level has.",
-                "For example, `'DEBUG'` (5 chars), or ` 'WARN'` (4 chars indented to 5 chars)."
+                "no matter the number of characters the log level has.",
+                "For example: `'DEBUG'` (5 chars) will not be indented, whereas ` 'WARN'` (4 chars) will be indented by one space character."
             ]
         },
         "message": {

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -15,7 +15,7 @@
             "type": "string",
             "required": true,
             "index": 1,
-            "nesting_allowed": false,
+            "nesting_required": true,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html"
         },
         "message": {
@@ -27,7 +27,7 @@
         "ecs.version": {
             "type": "string",
             "required": true,
-            "nesting_allowed": true,
+            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html"
         },
         "labels": {
@@ -44,21 +44,21 @@
         "trace.id": {
             "type": "string",
             "required": false,
-            "nesting_allowed": true,
+            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
             "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
         },
         "transaction.id": {
             "type": "string",
             "required": false,
-            "nesting_allowed": true,
+            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
             "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
         },
         "service.name": {
             "type": "string",
             "required": false,
-            "nesting_allowed": true,
+            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
             "comment": [
                 "Configurable by users.",
@@ -68,7 +68,7 @@
         "event.dataset": {
             "type": "string",
             "required": false,
-            "nesting_allowed": true,
+            "nesting_required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
             "default": "${service.name}.log OR ${service.name}.${appender.name}",
             "comment": [

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -15,8 +15,15 @@
             "type": "string",
             "required": true,
             "index": 1,
-            "nesting_allowed": false,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html"
+            "top_level_field": true,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
+            "comment": [
+                "This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.",
+                "This is to make the JSON logs more human-readable.",
+                "Loggers MAY indent the log level so that the `message` field always starts at the exact same offset,",
+                "no matter the number of character the log level has.",
+                "For example, `'DEBUG'` (5 chars), or ` 'WARN'` (4 chars indented to 5 chars)."
+            ]
         },
         "message": {
             "type": "string",

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -15,6 +15,7 @@
             "type": "string",
             "required": true,
             "index": 1,
+            "nesting_allowed": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html"
         },
         "message": {
@@ -26,6 +27,7 @@
         "ecs.version": {
             "type": "string",
             "required": true,
+            "nesting_allowed": true,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html"
         },
         "labels": {
@@ -42,18 +44,21 @@
         "trace.id": {
             "type": "string",
             "required": false,
+            "nesting_allowed": true,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
             "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
         },
         "transaction.id": {
             "type": "string",
             "required": false,
+            "nesting_allowed": true,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
             "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
         },
         "service.name": {
             "type": "string",
             "required": false,
+            "nesting_allowed": true,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
             "comment": [
                 "Configurable by users.",
@@ -63,6 +68,7 @@
         "event.dataset": {
             "type": "string",
             "required": false,
+            "nesting_allowed": true,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
             "default": "${service.name}.log OR ${service.name}.${appender.name}",
             "comment": [


### PR DESCRIPTION
While `log.level` is not allowed to be nested (for example `"log": { "level": "INFO" } }`) due to readability concerns, the same is not true for other properties, such as `trace.id`.