### PR TITLE
Overview docs

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,14 @@
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/ecs-logging/java/current/index.html[elastic.co]
+endif::[]
+
+= ECS Logging Reference
+
+ifndef::env-github[]
+include::./intro.asciidoc[Introduction]
+include::./setup.asciidoc[Set up]
+endif::[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -58,6 +58,18 @@ showing only the logs which belong to the corresponding request.
 Vice versa, you can also jump from a log line in the Logs UI to the Span Timeline of the APM UI.
 --
 
+*Broad support for languages and loggers*::
++
+--
+We have loggers for https://github.com/elastic/ecs-dotnet[.NET],
+Go (https://github.com/elastic/ecs-logging-go-zap[zap]),
+https://www.elastic.co/guide/en/ecs-logging/java/current/intro.html[Java],
+https://github.com/elastic/ecs-logging-js[JavaScript],
+https://github.com/elastic/ecs-logging-php[PHP],
+https://github.com/elastic/ecs-logging-python[Python],
+and https://github.com/elastic/ecs-logging-ruby[Ruby].
+--
+
 [float]
 ==== Additional advantages when using in combination with Filebeat
 
@@ -92,5 +104,5 @@ This is much more efficient than using daily indices.
 *Efficient Elasticsearch mappings*::
 +
 --
-Leverage Filebeat's default ECS-compatible {filebeat-ref}/configuration-template.html[index template]
+Leverage Filebeat's default ECS-compatible {filebeat-ref}/configuration-template.html[index template].
 --

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -61,7 +61,10 @@ Vice versa, you can also jump from a log line in the Logs UI to the Span Timelin
 [float]
 ==== Additional advantages when using in combination with Filebeat
 
-We recommend using this library to log into a JSON log file and using Filebeat to send the logs to Elasticsearch. Here are a few benefits to this approach.
+We recommend shipping the logs with Filebeat.
+Depending on the way the application is deployed, you may log to a log file or to stdout (for example in Kubernetes).
+
+Here are a few benefits to over directly sending logs from the application to Elasticsearch:
 
 *Resilient in case of outages*::
 +

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -1,0 +1,93 @@
+[[intro]]
+== Introduction
+
+Centralized application logging with the Elastic stack made easy.
+
+[role="screenshot"]
+image:https://user-images.githubusercontent.com/2163464/62682932-9cac3600-b9bd-11e9-9cc3-39e907280f8e.png[]
+
+[float]
+=== What is ECS?
+
+Elastic Common Schema (ECS) defines a common set of fields for ingesting data into Elasticsearch.
+For more information about ECS, visit the {ecs-ref}/ecs-reference.html[ECS Reference Documentation].
+
+[float]
+=== What is ECS logging?
+
+ECS loggers are plugins for your favorite logging library.
+They make it easy to format your logs into ECS-compatible JSON. For example:
+[source,json]
+----
+{"@timestamp":"2019-08-06T12:09:12.375Z", "log.level": "INFO", "message":"Tomcat started on port(s): 8080 (http) with context path ''", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.boot.web.embedded.tomcat.TomcatWebServer"}
+{"@timestamp":"2019-08-06T12:09:12.379Z", "log.level": "INFO", "message":"Started PetClinicApplication in 7.095 seconds (JVM running for 9.082)", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.samples.petclinic.PetClinicApplication"}
+{"@timestamp":"2019-08-06T14:08:40.199Z", "log.level":"DEBUG", "message":"init find form", "service.name":"spring-petclinic","process.thread.name":"http-nio-8080-exec-8","log.logger":"org.springframework.samples.petclinic.owner.OwnerController","transaction.id":"28b7fb8d5aba51f1","trace.id":"2869b25b5469590610fea49ac04af7da"}
+----
+
+[float]
+=== Why ECS logging?
+
+*No parsing of the log file required*::
++
+--
+ECS-compatible JSON doesn't require the use of Logstash or grok parsing via an ingest node pipeline.
+--
+
+*Decently human-readable JSON structure*::
++
+--
+The first three fields are always `@timestamp`, `log.level` and `message`.
+It's also possible to format stack traces so that each element is rendered in a new line.
+--
+
+*Enjoy the benefits of a common schema*::
++
+--
+Use the Kibana {observability-guide}/monitor-logs.html[Logs app] without additional configuration.
+
+Using a common schema across different services and teams makes it possible create reusable dashboards and avoids {ref}/mapping.html#mapping-limit-settings[mapping explosions].
+--
+
+*APM Log correlation*::
++
+--
+If you are using an {apm-agents-ref}/index.html[Elastic APM agent],
+you can leverage the {apm-get-started-ref}/observability-integrations.html#apm-logging-integration[log correlation feature] without any additional configuration.
+This lets you jump from the {kibana-ref}/spans.html[Span timeline in the APM UI] to the {observability-guide}/monitor-logs.html[Logs app],
+showing only the logs which belong to the corresponding request.
+Vice versa, you can also jump from a log line in the Logs UI to the Span Timeline of the APM UI.
+--
+
+[float]
+==== Additional advantages when using in combination with Filebeat
+
+We recommend using this library to log into a JSON log file and using Filebeat to send the logs to Elasticsearch. Here are a few benefits to this approach.
+
+*Resilient in case of outages*::
++
+--
+{filebeat-ref}/how-filebeat-works.html#at-least-once-delivery[Guaranteed at-least-once delivery]
+without buffering within the application, thus no risk of out of memory errors or lost events.
+There's also the option to use either the JSON logs or plain-text logs as a fallback.
+--
+
+*Loose coupling*::
++
+--
+The application does not need to know the details of the logging backend (URI, credentials, etc.).
+You can also leverage alternative {filebeat-ref}/configuring-output.html[Filebeat outputs],
+like Logstash, Kafka or Redis.
+--
+
+*Index Lifecycle management*::
++
+--
+Leverage Filebeat's default {filebeat-ref}/ilm.html[index lifecycle management settings].
+This is much more efficient than using daily indices.
+--
+
+*Efficient Elasticsearch mappings*::
++
+--
+Leverage Filebeat's default ECS-compatible {filebeat-ref}/configuration-template.html[index template]
+--

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -1,6 +1,8 @@
 [[setup]]
 == Get Started
 
+include::./tab-widgets/code.asciidoc[]
+
 [float]
 [[setup-step-1]]
 === Step 1: Configure application logging
@@ -20,33 +22,13 @@ Refer to the installation instructions of the individual loggers:
 [[setup-step-2]]
 === Step 2: Enable APM log correlation (optional)
 If you are using an Elastic APM agent,
-enable log correlation {apm-get-started-ref}/observability-integrations.html#apm-logging-integration.
+enable {apm-get-started-ref}/observability-integrations.html#apm-logging-integration[log correlation].
 
 [float]
 [[setup-step-3]]
 === Step 3: Configure Filebeat
 
-Configure your `filebeat.inputs` as follows:
-
-[source,yml]
-----
-filebeat.inputs:
-- type: log
-  paths: /path/to/logs.json
-  json.keys_under_root: true
-  json.overwrite_keys: true
-  # this is available as of Filebeat 7.11
-  # makes sure that log.level gets expanded to a nested object
-  json.expand_keys: true
-
-# no further processing required, logs can directly be sent to Elastic Cloud
-cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
-cloud.auth: "elastic:YOUR_PASSWORD"
-
-# Or to your local Elasticsearch cluster
-#output.elasticsearch:
-#  hosts: ["https://localhost:9200"]
-----
+include::./tab-widgets/filebeat-widget.asciidoc[]
 
 For more information, check the {filebeat-ref}/configuring-howto-filebeat.html[Filebeat documentation].
 

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -7,16 +7,14 @@ include::./tab-widgets/code.asciidoc[]
 [[setup-step-1]]
 === Step 1: Configure application logging
 
-Refer to the installation instructions of the individual loggers:
-
-* https://github.com/elastic/ecs-dotnet[.NET]
-* Go
-** https://github.com/elastic/ecs-logging-go-zap[zap]
-* https://www.elastic.co/guide/en/ecs-logging/java/current/intro.html[Java]
-* https://github.com/elastic/ecs-logging-js[JavaScript]
-* https://github.com/elastic/ecs-logging-php[PHP]
-* https://github.com/elastic/ecs-logging-python[Python]
-* https://github.com/elastic/ecs-logging-ruby[Ruby]
+Refer to the installation instructions of the individual loggers for
+https://github.com/elastic/ecs-dotnet#logging[.NET],
+Go (https://github.com/elastic/ecs-logging-go-zap[zap]),
+https://www.elastic.co/guide/en/ecs-logging/java/current/setup.html[Java],
+https://github.com/elastic/ecs-logging-js[JavaScript],
+https://github.com/elastic/ecs-logging-php[PHP],
+https://github.com/elastic/ecs-logging-python[Python],
+and https://github.com/elastic/ecs-logging-ruby[Ruby].
 
 [float]
 [[setup-step-2]]

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -1,0 +1,52 @@
+[[setup]]
+== Get Started
+
+[float]
+[[setup-step-1]]
+=== Step 1: Configure application logging
+
+Refer to the installation instructions of the individual loggers:
+
+* https://github.com/elastic/ecs-dotnet[.NET]
+* Go
+** https://github.com/elastic/ecs-logging-go-zap[zap]
+* https://www.elastic.co/guide/en/ecs-logging/java/current/intro.html[Java]
+* https://github.com/elastic/ecs-logging-js[JavaScript]
+* https://github.com/elastic/ecs-logging-php[PHP]
+* https://github.com/elastic/ecs-logging-python[Python]
+* https://github.com/elastic/ecs-logging-ruby[Ruby]
+
+[float]
+[[setup-step-2]]
+=== Step 2: Enable APM log correlation (optional)
+If you are using an Elastic APM agent,
+enable log correlation {apm-get-started-ref}/observability-integrations.html#apm-logging-integration.
+
+[float]
+[[setup-step-3]]
+=== Step 3: Configure Filebeat
+
+Configure your `filebeat.inputs` as follows:
+
+[source,yml]
+----
+filebeat.inputs:
+- type: log
+  paths: /path/to/logs.json
+  json.keys_under_root: true
+  json.overwrite_keys: true
+  # this is available as of Filebeat 7.11
+  # makes sure that log.level gets expanded to a nested object
+  json.expand_keys: true
+
+# no further processing required, logs can directly be sent to Elastic Cloud
+cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
+cloud.auth: "elastic:YOUR_PASSWORD"
+
+# Or to your local Elasticsearch cluster
+#output.elasticsearch:
+#  hosts: ["https://localhost:9200"]
+----
+
+For more information, check the {filebeat-ref}/configuring-howto-filebeat.html[Filebeat documentation].
+

--- a/docs/tab-widgets/code.asciidoc
+++ b/docs/tab-widgets/code.asciidoc
@@ -1,0 +1,166 @@
+// Defining styles and script here for simplicity.
+++++
+<style>
+.tabs {
+  width: 100%;
+}
+[role="tablist"] {
+  margin: 0 0 -0.1em;
+  overflow: visible;
+}
+[role="tab"] {
+  position: relative;
+  padding: 0.3em 0.5em 0.4em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0.2em 0.2em 0 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  background: hsl(220, 20%, 94%);
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before,
+[role="tab"][aria-selected="true"]::before {
+  position: absolute;
+  bottom: 100%;
+  right: -1px;
+  left: -1px;
+  border-radius: 0.2em 0.2em 0 0;
+  border-top: 3px solid hsl(219, 1%, 72%);
+  content: '';
+}
+[role="tab"][aria-selected="true"] {
+  border-radius: 0;
+  background: hsl(220, 43%, 99%);
+  outline: 0;
+}
+[role="tab"][aria-selected="true"]:not(:focus):not(:hover)::before {
+  border-top: 5px solid hsl(218, 96%, 48%);
+}
+[role="tab"][aria-selected="true"]::after {
+  position: absolute;
+  z-index: 3;
+  bottom: -1px;
+  right: 0;
+  left: 0;
+  height: 0.3em;
+  background: hsl(220, 43%, 99%);
+  box-shadow: none;
+  content: '';
+}
+[role="tab"]:hover,
+[role="tab"]:focus,
+[role="tab"]:active {
+  outline: 0;
+  border-radius: 0;
+  color: inherit;
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before {
+  border-color: hsl(218, 96%, 48%);
+}
+[role="tabpanel"] {
+  position: relative;
+  z-index: 2;
+  padding: 1em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0 0.2em 0.2em 0.2em;
+  box-shadow: 0 0 0.2em hsl(219, 1%, 72%);
+  background: hsl(220, 43%, 99%);
+  margin-bottom: 1em;
+}
+[role="tabpanel"] p {
+  margin: 0;
+}
+[role="tabpanel"] * + p {
+  margin-top: 1em;
+}
+</style>
+
+<script>
+window.addEventListener("DOMContentLoaded", () => {
+  const tabs = document.querySelectorAll('[role="tab"]');
+  const tabList = document.querySelector('[role="tablist"]');
+  // Add a click event handler to each tab
+  tabs.forEach(tab => {
+    tab.addEventListener("click", changeTabs);
+  });
+  // Enable arrow navigation between tabs in the tab list
+  let tabFocus = 0;
+  tabList.addEventListener("keydown", e => {
+    // Move right
+    if (e.keyCode === 39 || e.keyCode === 37) {
+      tabs[tabFocus].setAttribute("tabindex", -1);
+      if (e.keyCode === 39) {
+        tabFocus++;
+        // If we're at the end, go to the start
+        if (tabFocus >= tabs.length) {
+          tabFocus = 0;
+        }
+        // Move left
+      } else if (e.keyCode === 37) {
+        tabFocus--;
+        // If we're at the start, move to the end
+        if (tabFocus < 0) {
+          tabFocus = tabs.length - 1;
+        }
+      }
+      tabs[tabFocus].setAttribute("tabindex", 0);
+      tabs[tabFocus].focus();
+    }
+  });
+});
+
+function setActiveTab(target) {
+  const parent = target.parentNode;
+  const grandparent = parent.parentNode;
+  // console.log(grandparent);
+  // Remove all current selected tabs
+  parent
+    .querySelectorAll('[aria-selected="true"]')
+    .forEach(t => t.setAttribute("aria-selected", false));
+  // Set this tab as selected
+  target.setAttribute("aria-selected", true);
+  // Hide all tab panels
+  grandparent
+    .querySelectorAll('[role="tabpanel"]')
+    .forEach(p => p.setAttribute("hidden", true));
+  // Show the selected panel
+  grandparent.parentNode
+    .querySelector(`#${target.getAttribute("aria-controls")}`)
+    .removeAttribute("hidden");
+}
+
+function changeTabs(e) {
+  // get the containing list of the tab that was just clicked
+  const tabList = e.target.parentNode;
+
+  // get all of the sibling tabs
+  const buttons = Array.apply(null, tabList.querySelectorAll('button'));
+
+  // loop over the siblings to discover which index thje clicked one was
+  const { index } = buttons.reduce(({ found, index }, button) => {
+    if (!found && buttons[index] === e.target) {
+      return { found: true, index };
+    } else if (!found) {
+      return { found, index: index + 1 };
+    } else {
+      return { found, index };
+    }
+  }, { found: false, index: 0 });
+
+  // get the tab container
+  const container = tabList.parentNode;
+  // read the data-tab-group value from the container, e.g. "os"
+  const { tabGroup } = container.dataset;
+  // get a list of all the tab groups that match this value on the page
+  const groups = document.querySelectorAll('[data-tab-group=' + tabGroup + ']');
+
+  // for each of the found tab groups, find the tab button at the previously discovered index and select it for each group
+  groups.forEach((group) => {
+    const target = group.querySelectorAll('button')[index];
+    setActiveTab(target);
+  });
+}
+</script>
+++++

--- a/docs/tab-widgets/filebeat-widget.asciidoc
+++ b/docs/tab-widgets/filebeat-widget.asciidoc
@@ -1,0 +1,56 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="filebeat">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="logs-tab-install"
+            id="logs-install">
+      Log file
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="kubernetes-tab-install"
+            id="kubernetes-install">
+      Kubernetes
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="docker-tab-install"
+            id="docker-install">
+      Docker
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="logs-tab-install"
+       aria-labelledby="logs-install">
+++++
+
+include::filebeat.asciidoc[tag=logs]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="kubernetes-tab-install"
+       aria-labelledby="kubernetes-install"
+       hidden="">
+++++
+
+include::filebeat.asciidoc[tag=kubernetes]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="docker-tab-install"
+       aria-labelledby="docker-install"
+       hidden="">
+++++
+
+include::filebeat.asciidoc[tag=docker]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/tab-widgets/filebeat.asciidoc
+++ b/docs/tab-widgets/filebeat.asciidoc
@@ -1,0 +1,51 @@
+// tag::logs[]
+
+. Follow the {filebeat-ref}/filebeat-installation-configuration.html[Filebeat quick start]
+. Add the following configuration to your `filebeat.yaml` file.
+
+[source,yaml]
+.filebeat.yaml
+----
+filebeat.inputs:
+- type: log
+  paths: /path/to/logs.json
+  json.keys_under_root: true
+  json.overwrite_keys: true
+  json.add_error_key: true
+  json.expand_keys: true
+----
+// end::logs[]
+
+
+// tag::kubernetes[]
+. Follow the {filebeat-ref}/running-on-kubernetes.html[Run Filebeat on Kubernetes] guide.
+. Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover] (uncomment the corresponding section in `filebeat-kubernetes.yaml`).
+. Add these annotations to your pods that log using ECS loggers.
+  This will make sure the logs are parsed appropriately.
+
+[source,yaml]
+----
+annotations:
+  co.elastic.logs/json.keys_under_root: true
+  co.elastic.logs/json.overwrite_keys: true
+  co.elastic.logs/json.add_error_key: true
+  co.elastic.logs/json.expand_keys: true
+----
+// end::kubernetes[]
+
+
+// tag::docker[]
+. Follow the {filebeat-ref}/running-on-docker.html[Run Filebeat on Docker] guide.
+. Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover] (uncomment the corresponding section in `filebeat-kubernetes.yaml`).
+. Add these labels to your containers that log using ECS loggers.
+  This will make sure the logs are parsed appropriately.
+
+[source,yaml]
+----
+co.elastic.logs/json.keys_under_root: true
+co.elastic.logs/json.overwrite_keys: true
+co.elastic.logs/json.add_error_key: true
+co.elastic.logs/json.expand_keys: true
+----
+// end::docker[]
+

--- a/docs/tab-widgets/filebeat.asciidoc
+++ b/docs/tab-widgets/filebeat.asciidoc
@@ -18,6 +18,7 @@ filebeat.inputs:
 
 
 // tag::kubernetes[]
+. Make sure your application logs to stdout/stderr.
 . Follow the {filebeat-ref}/running-on-kubernetes.html[Run Filebeat on Kubernetes] guide.
 . Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover] (uncomment the corresponding section in `filebeat-kubernetes.yaml`).
 . Add these annotations to your pods that log using ECS loggers.
@@ -35,17 +36,20 @@ annotations:
 
 
 // tag::docker[]
+. Make sure your application logs to stdout/stderr.
 . Follow the {filebeat-ref}/running-on-docker.html[Run Filebeat on Docker] guide.
-. Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover] (uncomment the corresponding section in `filebeat-kubernetes.yaml`).
+. Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover].
 . Add these labels to your containers that log using ECS loggers.
   This will make sure the logs are parsed appropriately.
 
 [source,yaml]
+.docker-compose.yml
 ----
-co.elastic.logs/json.keys_under_root: true
-co.elastic.logs/json.overwrite_keys: true
-co.elastic.logs/json.add_error_key: true
-co.elastic.logs/json.expand_keys: true
+labels:
+  co.elastic.logs/json.keys_under_root: true
+  co.elastic.logs/json.overwrite_keys: true
+  co.elastic.logs/json.add_error_key: true
+  co.elastic.logs/json.expand_keys: true
 ----
 // end::docker[]
 


### PR DESCRIPTION
Preview of the setup page:

<img width="771" alt="Screen Shot 2020-12-08 at 18 00 57" src="https://user-images.githubusercontent.com/2163464/101516097-5daa3e00-397f-11eb-8677-dc40d46d3fe6.png">


TODOs
- Release on elastic.co
- Remove [intro section of the Java logger](https://www.elastic.co/guide/en/ecs-logging/java/current/intro.html) in favor of this
- Remove step 2 (Enable APM log correlation) and step 3 (configure filebeat) of the [Java get started docs](https://www.elastic.co/guide/en/ecs-logging/java/current/setup.html#setup-step-2) in favor of this.
- Decide on how to include/link to the general into section from the individual loggers (so far [Java](https://www.elastic.co/guide/en/ecs-logging/java/current/intro.html) and [.NET](https://github.com/elastic/ecs-dotnet/pull/120))

Follow-ups for later

Getting started guides for more platforms, such as PCF, S3, CloudWatch, Azure, ...


closes #31 