### PR TITLE
Add data_stream fields to spec

### DIFF
--- a/spec/spec.json
+++ b/spec/spec.json
@@ -82,7 +82,51 @@
                 "they should set `event.dataset=${service.name}.${appender.name}` if the appender name is available in the logging library.",
                 "Otherwise, agents should also set `event.dataset=${service.name}.log`",
                 "",
-                "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
+                "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection.",
+                "",
+                "Should have the same value as `data_stream.dataset`.",
+                "",
+                "In 8.0, `event.dataset` will be removed in favor of `data_stream.dataset`."
+            ]
+        },
+        "data_stream.dataset": {
+            "type": "string",
+            "required": false,
+            "url": "https://github.com/elastic/ecs/pull/1145",
+            "default": "${service.name}.log OR ${service.name}.${appender.name}",
+            "sanitization": {
+                "value": {
+                    "replacements": ["\\", "/", "*", "?", "\"", "<", ">", "|", " ", "-"],
+                    "substitute": "_",
+                    "max_chars": 100
+                }
+            },
+            "comment": [
+                "Configurable by users.",
+                "Influences which index the logs will be stored in (`logs-{data_stream.dataset}-{data_stream.namespace}`)",
+                "If unspecified, Filebeat will set the value to `default`.",
+                "",
+                "Should have the same value as `event.dataset`."
+            ]
+        },
+        "data_stream.namespace": {
+            "type": "string",
+            "required": false,
+            "url": "https://github.com/elastic/ecs/pull/1145",
+            "default": null,
+            "sanitization": {
+                "value": {
+                    "replacements": ["\\", "/", "*", "?", "\"", "<", ">", "|", " "],
+                    "substitute": "_",
+                    "max_chars": 100
+                }
+            },
+            "comment": [
+                "Configurable by users.",
+                "Influences which index the logs will be stored in (`logs-{data_stream.dataset}-{data_stream.namespace}`)",
+                "If unspecified, Filebeat will set the value to `default`.",
+                "",
+                "Should have the same value as `event.dataset`."
             ]
         },
         "process.thread.name": {

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -103,7 +103,7 @@
             },
             "comment": [
                 "Configurable by users.",
-                "Influences which index the logs will be stored in (`logs-{data_stream.dataset}-{data_stream.namespace}`)",
+                "Influences which data stream the logs will be stored in (`logs-{data_stream.dataset}-{data_stream.namespace}`)",
                 "If unspecified, Filebeat will set the value to `default`.",
                 "",
                 "Should have the same value as `event.dataset`."
@@ -123,7 +123,7 @@
             },
             "comment": [
                 "Configurable by users.",
-                "Influences which index the logs will be stored in (`logs-{data_stream.dataset}-{data_stream.namespace}`)",
+                "Influences which data stream the logs will be stored in (`logs-{data_stream.dataset}-{data_stream.namespace}`)",
                 "If unspecified, Filebeat will set the value to `default`.",
                 "",
                 "Should have the same value as `event.dataset`."

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -73,6 +73,14 @@
             "required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
             "default": "${service.name}.log OR ${service.name}.${appender.name}",
+            "sanitization": {
+                "value": {
+                    "replacements": ["\\", "/", "*", "?", "\"", "<", ">", "|", " ", ",", "#", ":", "-"],
+                    "substitute": "_",
+                    "max_chars": 100,
+                    "lower_case": true
+                }
+            },
             "comment": [
                 "Configurable by users.",
                 "If the user manually configures the service name,",
@@ -84,21 +92,20 @@
                 "",
                 "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection.",
                 "",
-                "Should have the same value as `data_stream.dataset`.",
-                "",
-                "In 8.0, `event.dataset` will be removed in favor of `data_stream.dataset`."
+                "Must be in sync with `data_stream.dataset`."
             ]
         },
         "data_stream.dataset": {
             "type": "string",
             "required": false,
-            "url": "https://github.com/elastic/ecs/pull/1145",
+            "url": "https://github.com/elastic/ecs/blob/master/rfcs/text/0009-data_stream-fields.md",
             "default": "${service.name}.log OR ${service.name}.${appender.name}",
             "sanitization": {
                 "value": {
-                    "replacements": ["\\", "/", "*", "?", "\"", "<", ">", "|", " ", "-"],
+                    "replacements": ["\\", "/", "*", "?", "\"", "<", ">", "|", " ", ",", "#", ":", "-"],
                     "substitute": "_",
-                    "max_chars": 100
+                    "max_chars": 100,
+                    "lower_case": true
                 }
             },
             "comment": [
@@ -106,7 +113,7 @@
                 "Influences which data stream the logs will be stored in (`logs-{data_stream.dataset}-{data_stream.namespace}`)",
                 "If unspecified, Filebeat will set the value to `generic`.",
                 "",
-                "Should have the same value as `event.dataset`."
+                "Must be in sync with `event.dataset`."
             ]
         },
         "data_stream.namespace": {
@@ -116,9 +123,10 @@
             "default": null,
             "sanitization": {
                 "value": {
-                    "replacements": ["\\", "/", "*", "?", "\"", "<", ">", "|", " "],
+                    "replacements": ["\\", "/", "*", "?", "\"", "<", ">", "|", " ", ",", "#", ":"],
                     "substitute": "_",
-                    "max_chars": 100
+                    "max_chars": 100,
+                    "lower_case": true
                 }
             },
             "comment": [
@@ -126,7 +134,7 @@
                 "Influences which data stream the logs will be stored in (`logs-{data_stream.dataset}-{data_stream.namespace}`)",
                 "If unspecified, Filebeat will set the value to `default`.",
                 "",
-                "Should have the same value as `event.dataset`."
+                "Must be in sync with `data_stream.dataset`."
             ]
         },
         "process.thread.name": {

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -104,7 +104,7 @@
             "comment": [
                 "Configurable by users.",
                 "Influences which data stream the logs will be stored in (`logs-{data_stream.dataset}-{data_stream.namespace}`)",
-                "If unspecified, Filebeat will set the value to `default`.",
+                "If unspecified, Filebeat will set the value to `generic`.",
                 "",
                 "Should have the same value as `event.dataset`."
             ]


### PR DESCRIPTION
[Data streams](https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html) are a new way of index management that is used by Elastic Agent. See also https://github.com/elastic/ecs/pull/1145.
To enable users to influence the data stream (and consequently, the index) the data is sent to, ECS loggers should offer configuration options for `data_stream.dataset` and `data_stream.namespace`. The data stream for logs is `logs-{data_stream.dataset}-{data_stream.namespace}`. As the settings are optional, Filebeat will default the values to `default` so that the data stream would be `logs-generic-default`.

The `event.dataset` field is going to be deprecated in favor of `data_stream.dataset` and scheduled to be removed for 8.0.

As we're planning to GA Elastic Agent in the 7.x timeframe, we'll have to support both `event.dataset` and `data_stream.dataset` for a while. Therefore, ECS loggers should set both fields with the same value, ideally before their initial GA release. This will make 7.x ECS loggers compatible with the 8.x stack.

When 8.0 comes along, ECS loggers should drop support for the `event.dataset` field. This would still allow 8.x loggers to be used with a 7.x stack. The only implication would be that the ML categorization job, which relies on `event.dataset`, wouldn't work. To fix that, users can use an ingest node processor to copy the value of `data_stream.dataset` to `event.dataset`, or downgrade their ECS logger to 7.x.