### PR TITLE
docs: update links to now published nodejs docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Learn more in the [ECS Logging Reference](https://www.elastic.co/guide/en/ecs-lo
 * [.NET](https://github.com/elastic/ecs-dotnet) ([docs](https://www.elastic.co/guide/en/ecs-logging/dotnet/current/intro.html))
   * [Serilog](https://github.com/elastic/ecs-dotnet/tree/master/src/Elastic.CommonSchema.Serilog)
   * [NLog](https://github.com/elastic/ecs-dotnet/tree/master/src/Elastic.CommonSchema.NLog)
-* [Node.js](https://github.com/elastic/ecs-logging-nodejs)
+* [Node.js](https://github.com/elastic/ecs-logging-nodejs) ([docs](https://www.elastic.co/guide/en/ecs-logging/nodejs/current/intro.html))
   * [Pino](https://github.com/elastic/ecs-logging-nodejs/tree/master/loggers/pino)
   * [Winston](https://github.com/elastic/ecs-logging-nodejs/tree/master/loggers/winston)
   * [Morgan](https://github.com/elastic/ecs-logging-nodejs/tree/master/loggers/morgan)

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -31,9 +31,9 @@ They make it easy to format your logs into ECS-compatible JSON. For example:
 Refer to the installation instructions of the individual loggers:
 
 * {ecs-logging-dotnet-ref}/setup.html[.NET]
-* Go: ({ecs-logging-go-zap-ref}/setup.html[zap]), ({ecs-logging-go-logrus-ref}/setup.html[logrus])
+* Go: {ecs-logging-go-zap-ref}/setup.html[zap], {ecs-logging-go-logrus-ref}/setup.html[logrus]
 * {ecs-logging-java-ref}/setup.html[Java]
-* https://github.com/elastic/ecs-logging-nodejs[Node.js]
+* Node.js: {ecs-logging-nodejs-ref}/morgan.html[morgan], {ecs-logging-nodejs-ref}/pino.html[pino], {ecs-logging-nodejs-ref}/winston.html[winston]
 * https://github.com/elastic/ecs-logging-php[PHP]
 * {ecs-logging-python-ref}/installation.html[Python]
 * {ecs-logging-ruby-ref}/setup.html[Ruby]


### PR DESCRIPTION
(This should wait for https://github.com/elastic/docs/pull/2048 to be in and time for docs to be published live.)