### PR TITLE
Relax requirements on field order to allow for frameworks that cannot

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -50,7 +50,7 @@ ECS-compatible JSON doesn't require the use of Logstash or grok parsing via an i
 *Decently human-readable JSON structure*::
 +
 --
-The first three fields are always `@timestamp`, `log.level` and `message`.
+The first three fields are `@timestamp`, `log.level` and `message`.
 It's also possible to format stack traces so that each element is rendered in a new line.
 --
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -2,7 +2,7 @@
 
 The specification aims to keep uniformity accross the libraries and to provide a human digestible output while producing a structured format.
 
-The ordering of the next three keys must be respected in every ecs-logging library:
+The ordering of the next three keys must be respected in every ecs-logging library (unless the logging framework makes this impossible):
 
 1. `@timestamp`, base field
 2. `log.level`, log field

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -9,7 +9,11 @@
             "type": "datetime",
             "required": true,
             "index": 0,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html"
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html",
+            "comment": [
+                "Field order, as specified by 'index', is RECOMMENDED.",
+                "ECS loggers must implement field order unless the logging framework makes that impossible."
+            ]
         },
         "log.level": {
             "type": "string",


### PR DESCRIPTION
This relaxes the language and spec on the field order of
@timestamp, log.level, message for frameworks (notably pino and
zap) that cannot support it.

Fixes: #42