### PR TITLE
docs: link to ecs-logging-php docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Learn more in the [ECS Logging Reference](https://www.elastic.co/guide/en/ecs-lo
   * [Log4j](https://www.elastic.co/guide/en/ecs-logging/java/current/setup.html)
   * [Java Util Logging](https://www.elastic.co/guide/en/ecs-logging/java/current/setup.html)
   * [JBoss LogManager](https://www.elastic.co/guide/en/ecs-logging/java/current/setup.html)
-* [PHP](https://github.com/elastic/ecs-logging-php)
+* [PHP](https://github.com/elastic/ecs-logging-php) ([docs](https://www.elastic.co/guide/en/ecs-logging/php/current/intro.html))
   * [Monolog v2.x](https://github.com/elastic/ecs-logging-php/blob/master/docs/Monolog_v2.md)
 * [.NET](https://github.com/elastic/ecs-dotnet) ([docs](https://www.elastic.co/guide/en/ecs-logging/dotnet/current/intro.html))
   * [Serilog](https://github.com/elastic/ecs-dotnet/tree/master/src/Elastic.CommonSchema.Serilog)

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -34,7 +34,7 @@ Refer to the installation instructions of the individual loggers:
 * Go: {ecs-logging-go-zap-ref}/setup.html[zap], {ecs-logging-go-logrus-ref}/setup.html[logrus]
 * {ecs-logging-java-ref}/setup.html[Java]
 * Node.js: {ecs-logging-nodejs-ref}/morgan.html[morgan], {ecs-logging-nodejs-ref}/pino.html[pino], {ecs-logging-nodejs-ref}/winston.html[winston]
-* https://github.com/elastic/ecs-logging-php[PHP]
+* {ecs-logging-php-ref}/setup.html[PHP]
 * {ecs-logging-python-ref}/installation.html[Python]
 * {ecs-logging-ruby-ref}/setup.html[Ruby]
 

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -51,7 +51,7 @@ ECS-compatible JSON doesn't require the use of Logstash or grok parsing via an i
 +
 --
 The first three fields are `@timestamp`, `log.level` and `message`.
-This lets easily read the logs in a terminal without needing a tool that converts the logs to plain-text.
+This lets you easily read the logs in a terminal without needing a tool that converts the logs to plain-text.
 --
 
 *Enjoy the benefits of a common schema*::


### PR DESCRIPTION
Link to ecs-logging-php documentation.

~Currently blocked by https://github.com/elastic/docs/pull/2055.~