### PR TITLE
Adding service.version

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -74,6 +74,7 @@ The following example describes a richer set of fields in an event that has not 
     "trace.id": "4bf92f3577b34da6a3ce929d0e0e4736",
     "transaction.id": "00f067aa0ba902b7",
     "service.name": "opbeans",
+    "service.version": "1.2.3",
     "event.dataset": "opbeans.log"
 }
 ```

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -76,6 +76,15 @@
                 "When an APM agent is active, they should auto-configure it if not already set."
             ]
         },
+        "service.version": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, they should auto-configure it if not already set."
+            ]
+        },
         "event.dataset": {
             "type": "string",
             "required": false,

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -79,10 +79,10 @@
         "service.version": {
             "type": "string",
             "required": false,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-version",
             "comment": [
                 "Configurable by users.",
-                "When an APM agent is active, they should auto-configure it if not already set."
+                "When an APM agent is active, it should auto-configure it if not already set."
             ]
         },
         "event.dataset": {


### PR DESCRIPTION
Adding the `service.version` field as an user-configurable option.

Requested via https://github.com/elastic/ecs-logging-java/issues/129

> maybe you can just support a service.version to have a basic context of application name and version (easy to use and discover using the builder api or in config files)? imo, these two fileds are a 'must-have' when dealing wih logs or metrics

That makes sense to me. WDYT?