### PR TITLE
Adding service.environment to the spec

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -75,6 +75,7 @@ The following example describes a richer set of fields in an event that has not 
     "transaction.id": "00f067aa0ba902b7",
     "service.name": "opbeans",
     "service.version": "1.2.3",
+    "service.environment": "production",
     "event.dataset": "opbeans.log"
 }
 ```

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -96,7 +96,7 @@
         "service.environment": {
             "type": "string",
             "required": false,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-environment",
             "comment": [
                 "Configurable by users."
             ]

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -98,7 +98,8 @@
             "required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-environment",
             "comment": [
-                "Configurable by users."
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure it if not already set."
             ]
         },
         "process.thread.name": {

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -93,6 +93,14 @@
                 "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
             ]
         },
+        "service.environment": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "comment": [
+                "Configurable by users."
+            ]
+        },
         "process.thread.name": {
             "type": "string",
             "required": false,


### PR DESCRIPTION
There is no `service.environment` field in ECS at the moment, but there is an [RFC](https://github.com/elastic/ecs/blob/master/rfcs/text/0002-rfc-environment.md) to add it.
This PR is blocked until it is added.