### PR TITLE
Remove .log suffix from default event.dataset

### DIFF
--- a/spec/spec.json
+++ b/spec/spec.json
@@ -89,15 +89,15 @@
             "type": "string",
             "required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
-            "default": "${service.name}.log OR ${service.name}.${appender.name}",
+            "default": "${service.name} OR ${service.name}.${appender.name}",
             "comment": [
                 "Configurable by users.",
                 "If the user manually configures the service name,",
-                "the logging library should set `event.dataset=${service.name}.log` if not explicitly configured otherwise.",
+                "the logging library should set `event.dataset=${service.name}` if not explicitly configured otherwise.",
                 "",
                 "When agents auto-configure the app to use an ECS logger,",
                 "they should set `event.dataset=${service.name}.${appender.name}` if the appender name is available in the logging library.",
-                "Otherwise, agents should also set `event.dataset=${service.name}.log`",
+                "Otherwise, agents should also set `event.dataset=${service.name}`",
                 "",
                 "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
             ]


### PR DESCRIPTION
The `.log` suffix in `event.dataset` is considered bad practice, according to @ruflin.
Instead of `my_service.log`, `my_service` is preferred for the `event.dataset`.

@weltenwort do you agree with that?

See also the discussion in https://github.com/elastic/beats/issues/27404#issuecomment-900137618
> Having .log in the dataset name is a bit unfortunate. That it is a log should be defined by the type already. Lets remove it.

