### PR TITLE
Add service.environment and service.version fields to the spec

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -74,6 +74,8 @@ The following example describes a richer set of fields in an event that has not 
     "trace.id": "4bf92f3577b34da6a3ce929d0e0e4736",
     "transaction.id": "00f067aa0ba902b7",
     "service.name": "opbeans",
+    "service.environment": "production",
+    "service.version": "1.2.3",
     "event.dataset": "opbeans.log"
 }
 ```

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -76,6 +76,24 @@
                 "When an APM agent is active, it should auto-configure this field if not already set."
             ]
         },
+        "service.environment": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-environment",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure this field if not already set."
+            ]
+        },
+        "service.version": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-version",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure this field if not already set."
+            ]
+        },
         "service.node.name": {
             "type": "string",
             "required": false,


### PR DESCRIPTION
Recently added in ecs-logging-java at the request of users and @cyrille-leclerc 

* https://github.com/elastic/ecs-logging-java/pull/168
* https://github.com/elastic/ecs-logging-java/pull/184