### PR TITLE
Ensure ecs.version is treated as a top level field

### DIFF
--- a/spec/spec.json
+++ b/spec/spec.json
@@ -42,7 +42,12 @@
         "ecs.version": {
             "type": "string",
             "required": true,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html"
+            "top_level_field": true,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html",
+            "comment": [
+                "This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.",
+                "This is to make the JSON logs more human-readable."
+            ]
         },
         "labels": {
             "type": "object",


### PR DESCRIPTION
This ensures the `ecs.version` is always written as top level field without arbitrary nesting it.

This aligns the spec closer to the written documentation:

https://github.com/elastic/ecs-logging/tree/main/spec#minimum-viable-product