### PR TITLE
add service.{version,environment} to docs

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -186,6 +186,15 @@ Refer to the documentation of the individual loggers on how to set these fields.
 | Helps to filter the logs by service.
 |`"my-service"`
 
+|{ecs-ref}/ecs-service.html[`service.version`]
+| Helps to filter the logs by service version.
+|`"1.0"`
+
+|{ecs-ref}/ecs-service.html[`service.environment`]
+| Helps to filter the logs by environment.
+|`"production"`
+
+
 |{ecs-ref}/ecs-event.html[`event.dataset`]
 | Enables the {observability-guide}/inspect-log-anomalies.html[log rate anomaly detection].
 |`"my-service.log"`


### PR DESCRIPTION
Add service-level correlation fields documentation, both are already included in the [specification examples](https://github.com/elastic/ecs-logging/tree/main/spec#a-richer-event-context).
- `service.environment`
- `service.version`