### PR TITLE
docs: clean up remaining ".log" suffix examples in docs

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -197,7 +197,7 @@ Refer to the documentation of the individual loggers on how to set these fields.
 
 |{ecs-ref}/ecs-event.html[`event.dataset`]
 | Enables the {observability-guide}/inspect-log-anomalies.html[log rate anomaly detection].
-|`"my-service.log"`
+|`"my-service"`
 
 |===
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -76,7 +76,7 @@ The following example describes a richer set of fields in an event that has not 
     "service.name": "opbeans",
     "service.version": "1.2.3",
     "service.environment": "production",
-    "event.dataset": "opbeans.log"
+    "event.dataset": "opbeans"
 }
 ```
 


### PR DESCRIPTION
Back in #63 the guidance was changed to *not* have the .log
suffix on `event.dataset`.
