### PR TITLE
docs: mention that `service.node.name` is configurable

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -194,6 +194,9 @@ Refer to the documentation of the individual loggers on how to set these fields.
 | Helps to filter the logs by environment.
 |`"production"`
 
+|{ecs-ref}/ecs-service.html[`service.node.name`]
+| Allow for two nodes of the same service, on the same host to be differentiated.
+|`"instance-0000000016"`
 
 |{ecs-ref}/ecs-event.html[`event.dataset`]
 | Enables the {observability-guide}/inspect-log-anomalies.html[log rate anomaly detection].


### PR DESCRIPTION
In #61 service.node.name was added to the ecs-logging spec as
"Configurable by users".

---

FWIW, ecs-logging-java already *does* make this configurable via its `setServiceNodeName()` methods.