### PR TITLE
docs: filebeat config: fix parsers.ndjson indentation

### DIFF
--- a/docs/tab-widgets/filebeat.asciidoc
+++ b/docs/tab-widgets/filebeat.asciidoc
@@ -13,9 +13,9 @@ filebeat.inputs:
   paths: /path/to/logs.json
   parsers:
     - ndjson:
-      overwrite_keys: true <2>
-      add_error_key: true <3>
-      expand_keys: true <4>
+        overwrite_keys: true <2>
+        add_error_key: true <3>
+        expand_keys: true <4>
 
 processors: <5>
   - add_host_metadata: ~


### PR DESCRIPTION
The current code snippet has a problem in the indentation in the `parsers.ndjson` block.

[parser documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#_parsers)
[correct configuration in the issues beats/29531](https://github.com/elastic/beats/issues/29531#issuecomment-1727584016)